### PR TITLE
give the lambda more memory so it has more CPU to see if it runs faster

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,7 @@ provider:
   runtime: nodejs6.10
   region: us-west-2
   timeout: 30
-  memorySize: 128
+  memorySize: 1024
   iamRoleStatements:
     -  Effect: "Allow"
        Action:


### PR DESCRIPTION
1024MB is the serverless default for Lambda