### PR TITLE
pin cats-effect and fs2 to v2

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+updates.pin = [ 
+  { groupId = "co.fs2", version = "2." },
+  { groupId = "org.typelevel", artifactId="cats-effect-laws", version = "2." },
+  { groupId = "org.typelevel", artifactId="cats-effect", version = "2." }
+]


### PR DESCRIPTION
This Lambda would need to be switched to use Feral to update these libraries, so pin them for now.