### PR TITLE
fix(ci): update Mergify config for current schema

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,9 @@
 queue_rules:
   - name: default
-    conditions:
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.11)
+    merge_conditions:
+      - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@8)
+      - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@11)
+    merge_method: squash
 
 pull_request_rules:
   - name: assign and label scala-steward's PRs
@@ -21,9 +22,8 @@ pull_request_rules:
   - name: merge scala-steward's PRs
     conditions:
       - author=scala-steward
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.11)
+      - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@8)
+      - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@11)
     actions:
       queue:
-        method: squash
         name: default


### PR DESCRIPTION
## Summary
Mergify reads `.mergify.yml` from **main**, so the fix on #187 does not apply until this lands. Main still uses deprecated `queue.method: squash`, which fails config validation and blocks the merge queue for all PRs.

- Move `method: squash` → `queue_rules.merge_method: squash`
- Rename `conditions` → `merge_conditions` in queue rules
- Update CI status names to `2.13.8, temurin@8/11`

## Test plan
- [ ] **Admin-merge this PR** (Mergify cannot queue it while config is invalid)
- [ ] Confirm Mergify checks pass on #187
- [ ] Close superseded #189